### PR TITLE
Fix crash related to Major City

### DIFF
--- a/ipad/Models/Waterfract Inspection/WatercraftInspectionModel.swift
+++ b/ipad/Models/Waterfract Inspection/WatercraftInspectionModel.swift
@@ -276,7 +276,7 @@ class WatercradftInspectionModel: Object, BaseRealmObject {
             "previousDryStorage": previousDryStorage,
             "destinationDryStorage": destinationDryStorage,
             "previousMajorCity": previousMajorCities.count > 0 ? (previousMajorCities[0].majorCity + ", " + previousMajorCities[0].province + ", " + previousMajorCities[0].country) : "None",
-            "destinationMajorCity": destinationMajorCities.count > 0 ? (destinationMajorCities[0].majorCity + ", " + previousMajorCities[0].province + ", " + previousMajorCities[0].country) : "None",
+            "destinationMajorCity": destinationMajorCities.count > 0 ? (destinationMajorCities[0].majorCity + ", " + destinationMajorCities[0].province + ", " + destinationMajorCities[0].country) : "None",
             "unknownPreviousWaterBody": unknownPreviousWaterBody,
             "unknownDestinationWaterBody": unknownDestinationWaterBody,
             "commercialManufacturerAsPreviousWaterBody": commercialManufacturerAsPreviousWaterBody,


### PR DESCRIPTION
Fixed a crash where the app was attempting to index into an array that was not yet initialized. Was indexing into Previous Major Cities when it should have been looking at Destination Major Cities.