### PR TITLE
Add validation for watercraft types when submitting inspection

### DIFF
--- a/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
+++ b/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
@@ -174,7 +174,7 @@ class WatercraftInspectionViewController: BaseViewController {
         let deleteButton = UIBarButtonItem(image: deleteIcon,  style: .plain, target: self, action: #selector(self.didTapDeleteButton(sender:)))
         
         let saveIcon = UIImage(systemName: "checkmark")
-        let saveButton = UIBarButtonItem(image: saveIcon,  style: .plain, target: self, action: #selector(self.action(sender:)))
+        let saveButton = UIBarButtonItem(image: saveIcon,  style: .plain, target: self, action: #selector(self.didTapCheckmarkButton(sender:)))
         
         navigationItem.rightBarButtonItems = [saveButton, deleteButton]
     }
@@ -209,8 +209,35 @@ class WatercraftInspectionViewController: BaseViewController {
         }
     }
     
-    @objc func action(sender: UIBarButtonItem) {
+    // Watercraft Inspection submission (checkmark)
+    @objc func didTapCheckmarkButton(sender: UIBarButtonItem) {
+        
+        // Allow exit if all other information is nil
+        guard let model = self.model else {return}
         self.dismissKeyboard()
+        
+        // Check if any of the watercraft types are at least greater than 0
+        // If this is a passport holder, watercraft types visible when issuing
+        // a new passport of if launchedOutsideBC is checked on
+        if (!model.isPassportHolder &&
+            model.nonMotorized == 0 &&
+            model.simple == 0 &&
+            model.complex == 0 &&
+            model.veryComplex == 0) ||
+            
+            (model.isPassportHolder &&
+             (model.launchedOutsideBC || model.isNewPassportIssued) &&
+             model.nonMotorized == 0 &&
+             model.simple == 0 &&
+             model.complex == 0 &&
+             model.veryComplex == 0)
+        {
+        
+            Alert.show(title: "Watercraft Required", message: "Add at least one of the following Watercraft Types in Basic Information:\n\n - Non-Motorized\n - Simple\n - Complex\n - Very Complex")
+            
+            return
+        }
+        
         self.navigationController?.popViewController(animated: true)
     }
     

--- a/ipad/Views/Sync view/SyncView.swift
+++ b/ipad/Views/Sync view/SyncView.swift
@@ -136,7 +136,7 @@ class SyncView: ModalView, Theme {
     
     func showSyncInProgressAnimation() {
         clearIcon()
-        let animationView = AnimationView(name: "sync-circle")
+        let animationView = LottieAnimationView(name: "sync-circle")
         animationView.frame = statusIconView.frame
         animationView.center.y = statusIconView.center.y
         animationView.center.x = statusIconView.center.x
@@ -157,7 +157,7 @@ class SyncView: ModalView, Theme {
     
     func showSyncFailedAnimation() {
         clearIcon()
-        let animationView = AnimationView(name: "unapproved-cross")
+        let animationView = LottieAnimationView(name: "unapproved-cross")
         animationView.frame = statusIconView.frame
         animationView.center.y = statusIconView.center.y
         animationView.center.x = statusIconView.center.x
@@ -178,7 +178,7 @@ class SyncView: ModalView, Theme {
     
     func showSyncCompletedAnimation() {
         clearIcon()
-        let animationView = AnimationView(name: "check-mark-success")
+        let animationView = LottieAnimationView(name: "check-mark-success")
         animationView.frame = statusIconView.frame
         animationView.center.y = statusIconView.center.y
         animationView.center.x = statusIconView.center.x


### PR DESCRIPTION
Update the submission button for Watercraft Inspection to include a simple validation check. Checks if at least one watercraft type has been tallied during inspection, otherwise alerts user of the error. Validates if the "Passport" option has been toggled and it's issuing a new passport or if the watercraft has been launched outside BC.

<img width="424" alt="Screenshot 2023-01-24 at 4 41 02 PM" src="https://user-images.githubusercontent.com/62899351/214454034-7a915251-daf5-477f-967b-d0fee423e6ac.png">

Also includes update to AnimateView for Lottie change (LottieAnimateView) as per Chris Walsh's discovery.
