### PR TITLE
Inspect form fields updates

### DIFF
--- a/ipad/Constants/StringConstants.swift
+++ b/ipad/Constants/StringConstants.swift
@@ -99,7 +99,7 @@ struct WatercraftFieldHeaderConstants {
         static let veryComplex = "Very Complex"
     }
     struct WatercraftDetails {
-        static let numberOfPeopleInParty = "Number of people in the party"
+        static let numberOfPeopleInParty = "Number of people in the party *"
         static let commerciallyHauled = "Watercraft/equipment commercially hauled *"
         static let highRiskArea = "Watercraft coming from a high risk area for whirling disease"
         static let previousAISKnowlede = "Previous Knowledge of AIS or Clean, Drain, Dry *"

--- a/ipad/Constants/StringConstants.swift
+++ b/ipad/Constants/StringConstants.swift
@@ -143,7 +143,7 @@ struct HighRiskFormFieldHeaders {
         static let adultDreissenidMusselsLocation = "Adult Dreissenid mussels location"
         static let dreisennidFoundPrevious = "Dreissenid mussels found during previous inspection and FULL decontamination already completed/determined to be CDD *"
         static let decontaminationPerformed = "Decontamination performed? *"
-        static let decontaminationReference = "Record of Decontamination number"
+        static let decontaminationReference = "Record of Decontamination number *"
         static let decontaminationOrderIssued = "Decontamination order issued? *"
         static let decontaminationOrderNumber = "Decontamination order number *"
         static let decontaminationOrderReason = "Reason for issuing decontamination order *"

--- a/ipad/Constants/StringConstants.swift
+++ b/ipad/Constants/StringConstants.swift
@@ -141,7 +141,7 @@ struct HighRiskFormFieldHeaders {
         static let standingWaterLocation = "Standing Water Location"
         static let adultDreissenidMusselsFound = "Adult dreissenid mussels found?"
         static let adultDreissenidMusselsLocation = "Adult Dreissenid mussels location"
-        static let dreisennidFoundPrevious = "Dreissenid mussels found during previous inspection and FULL decontamination already completed *"
+        static let dreisennidFoundPrevious = "Dreissenid mussels found during previous inspection and FULL decontamination already completed/determined to be CDD *"
         static let decontaminationPerformed = "Decontamination performed? *"
         static let decontaminationReference = "Record of Decontamination number"
         static let decontaminationOrderIssued = "Decontamination order issued? *"

--- a/ipad/Constants/StringConstants.swift
+++ b/ipad/Constants/StringConstants.swift
@@ -147,7 +147,7 @@ struct HighRiskFormFieldHeaders {
         static let decontaminationOrderIssued = "Decontamination order issued? *"
         static let decontaminationOrderNumber = "Decontamination order number *"
         static let decontaminationOrderReason = "Reason for issuing decontamination order *"
-        static let decontaminationAppendixB = "Appendix B filled out? *"
+        static let decontaminationAppendixB = "Appendix B completed and served? *"
         static let sealIssued = "Seal issued or existing seal? *"
         static let sealNumber = "Seal # *"
     }

--- a/ipad/Models/Waterfract Inspection/Form Fields/HighRiskFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/HighRiskFormHelper.swift
@@ -91,6 +91,16 @@ class HighRiskFormHelper {
         sectionItems.append(spacer2)
         /// ---------------------------
         
+        let otherInspectionFindings = DropdownInput(
+            key: "highRisk-otherInspectionFindings",
+            header: HighRiskFormFieldHeaders.InspectionOutcomes.otherInspectionFindings,
+            editable: editable ?? true,
+            value: object?.otherInspectionFindings ?? "",
+            width: .Full,
+            dropdownItems: DropdownHelper.shared.getDropdown(for: .otherObservations)
+        )
+        sectionItems.append(otherInspectionFindings)
+        
         let decontaminationPerformed = NullSwitchInput(
             key: "highRisk-decontaminationPerformed",
             header: HighRiskFormFieldHeaders.InspectionOutcomes.decontaminationPerformed,
@@ -195,22 +205,12 @@ class HighRiskFormHelper {
 //        )
 //        sectionItems.append(dreissenidMusselsFoundPrevious)
         
-        let otherInspectionFindings = DropdownInput(
-            key: "highRisk-otherInspectionFindings",
-            header: HighRiskFormFieldHeaders.InspectionOutcomes.otherInspectionFindings,
-            editable: editable ?? true,
-            value: object?.otherInspectionFindings ?? "",
-            width: .Half,
-            dropdownItems: DropdownHelper.shared.getDropdown(for: .otherObservations)
-        )
-        sectionItems.append(otherInspectionFindings)
-        
         let quarantinePeriodIssued = NullSwitchInput(
             key: "highRisk-quarantinePeriodIssued",
             header: HighRiskFormFieldHeaders.InspectionOutcomes.quarantinePeriodIssued,
             editable: editable ?? true,
             value: object?.quarantinePeriodIssued ?? false,
-            width: .Half,
+            width: .Full,
             validationName: .quarantinePeriodIssuedInteracted,
             interacted: object?.quarantinePeriodIssuedInteracted ?? false
         )

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -396,10 +396,10 @@ class WatercraftInspectionFormHelper {
             // --------- End of Basic Information Validaiton ---------
             
             // --------- Watercraft Details Validation ---------
-            if !(object?.isPassportHolder ?? false) &&
+            if isPassportHolderNewOrLaunched &&
                 object?.numberOfPeopleInParty ?? 0 < 1 { return false }
             
-            if !(object?.isPassportHolder ?? false) &&
+            if isPassportHolderNewOrLaunched &&
                 !(object?.commerciallyHauledInteracted ?? false) { return false }
                     
             if isPassportHolderNewOrLaunched &&

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -293,7 +293,7 @@ class WatercraftInspectionFormHelper {
         return sectionItems
     }
     
-    static func getInspectionDetailsFields(for object: WatercraftInspectionModel? = nil, editable: Bool? = true) -> [InputItem] {
+    static func getInspectionDetailsFields(for object: WatercraftInspectionModel? = nil, editable: Bool? = true, passportField: RadioSwitchInput) -> [InputItem]  {
         var sectionItems: [InputItem] = []
         let aquaticPlantsFound = SwitchInput(
             key: "aquaticPlantsFound",
@@ -341,6 +341,18 @@ class WatercraftInspectionFormHelper {
             interacted: object?.dreissenidMusselsFoundPreviousInteracted ?? false
         )
         sectionItems.append(dreissenidMusselsFoundPrevious)
+        
+        let k9Inspection = NullSwitchInput(
+            key: "k9Inspection",
+            header: WatercraftFieldHeaderConstants.Passport.k9Inspection,
+            editable: editable ?? true,
+            value: object?.k9Inspection ?? nil,
+            width: .Full,
+            validationName: .k9InspectionInteracted,
+            interacted: object?.k9InspectionInteracted ?? false
+        )
+        k9Inspection.dependency.append(InputDependency(to: passportField, equalTo: false))
+        sectionItems.append(k9Inspection)
         
         return sectionItems
     }

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -371,10 +371,18 @@ class WatercraftInspectionFormHelper {
     
     static func getGeneralCommentsFields(for object: WatercraftInspectionModel? = nil, editable: Bool? = true) -> [InputItem] {
         var sectionItems: [InputItem] = []
+        
+        // Only allow comments once mandatory sections have been completed
+        let editable =  object?.k9InspectionInteracted ?? false &&
+                        object?.previousInspectionInteracted ?? false &&
+                        object?.commerciallyHauledInteracted ?? false &&
+                        object?.previousAISKnowledeInteracted ?? false &&
+                        object?.dreissenidMusselsFoundPreviousInteracted ?? false
+        
         let generalComments = TextAreaInput(
             key: "generalComments",
             header: WatercraftFieldHeaderConstants.GeneralComments.generalComments,
-            editable: editable ?? true,
+            editable: editable,
             value: object?.generalComments ?? "",
             width: .Full
         )

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -480,7 +480,8 @@ class WatercraftInspectionFormHelper {
 
             return true
         }
-           
+        
+        // general comment section is only available if mandatory fields are completed
         let editable = validationCheck()
         
         let generalComments = TextAreaInput(

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -394,9 +394,10 @@ class WatercraftInspectionFormHelper {
             key: "generalComments",
             header: WatercraftFieldHeaderConstants.GeneralComments.generalComments,
             editable: editable,
-            value: object?.generalComments ?? "",
+            value: editable ? (object?.generalComments ?? "") : "Complete all required fields (*) to add comments.",
             width: .Full
         )
+        
         sectionItems.append(generalComments)
         return sectionItems
     }

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -143,22 +143,10 @@ class WatercraftInspectionFormHelper {
             header: WatercraftFieldHeaderConstants.Passport.inspectionTime,
             editable: editable ?? true,
             value: object?.inspectionTime ?? nil,
-            width: .Third
+            width: .Half
         )
         inspectionTime.dependency.append(InputDependency(to: passportField, equalTo: false))
         sectionItems.append(inspectionTime)
-        
-        let k9Inspection = NullSwitchInput(
-            key: "k9Inspection",
-            header: WatercraftFieldHeaderConstants.Passport.k9Inspection,
-            editable: editable ?? true,
-            value: object?.k9Inspection ?? nil,
-            width: .Third,
-            validationName: .k9InspectionInteracted,
-            interacted: object?.k9InspectionInteracted ?? false
-        )
-        k9Inspection.dependency.append(InputDependency(to: passportField, equalTo: false))
-        sectionItems.append(k9Inspection)
         
         let spacer = InputSpacer(width: .Third)
         spacer.dependency.append(InputDependency(to: passportField, equalTo: true))

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -508,7 +508,7 @@ class WatercraftInspectionFormHelper {
 
             let numberOfDaysOut = DropdownInput(
                 key: "previousWaterBody-numberOfDaysOut-\(index)",
-                header: "Number of days out of waterbody?",
+                header: "Number of days out of waterbody? *",
                 editable: isEditable ?? true,
                 value: item?["numberOfDaysOut"] as? String ?? "N/A",
                 width: .Full,

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -427,11 +427,39 @@ class WatercraftInspectionFormHelper {
             // --------- End of Watercraft Details Validaiton ---------
             
             // --------- Journey Details Validation ---------
-            if object?.unknownPreviousWaterBody == true ||
+            
+            if isPassportHolderNewOrLaunched &&
+                object?.unknownPreviousWaterBody == false ||
+                object?.commercialManufacturerAsPreviousWaterBody == false ||
+                object?.previousDryStorage == false {
+                if object?.previousWaterBodies.isEmpty ?? false { return false }
+                if let object = object {
+                    for prev in object.previousWaterBodies {
+                        if prev.numberOfDaysOut.isEmpty {
+                            return false
+                        }
+                    }
+                }
+            }
+                
+            if isPassportHolderNewOrLaunched &&
+                object?.unknownPreviousWaterBody == true ||
                 object?.commercialManufacturerAsPreviousWaterBody == true ||
-                object?.previousDryStorage == true { return false }
+                object?.previousDryStorage == true {
+                if object?.previousMajorCities.isEmpty ?? false {
+                    return false
+                }
+            }
 
-            if object?.unknownDestinationWaterBody == true ||
+            if isPassportHolderNewOrLaunched &&
+                object?.unknownDestinationWaterBody == false ||
+                object?.commercialManufacturerAsDestinationWaterBody == false ||
+                object?.destinationDryStorage == false {
+                if object?.destinationWaterBodies.isEmpty ?? false { return false }
+            }
+            
+            if isPassportHolderNewOrLaunched &&
+                object?.unknownDestinationWaterBody == true ||
                 object?.commercialManufacturerAsDestinationWaterBody == true ||
                 object?.destinationDryStorage == true {
                 if object?.destinationMajorCities.isEmpty ?? false { return false }

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -397,7 +397,7 @@ class WatercraftInspectionFormHelper {
             
             // --------- Watercraft Details Validation ---------
             if isPassportHolderNewOrLaunched &&
-                object?.numberOfPeopleInParty < 1 ?? 0 { return false }
+                object?.numberOfPeopleInParty ?? 0 < 1 { return false }
             
             if isPassportHolderNewOrLaunched &&
                 !(object?.commerciallyHauledInteracted ?? false) { return false }

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -372,8 +372,19 @@ class WatercraftInspectionFormHelper {
     static func getGeneralCommentsFields(for object: WatercraftInspectionModel? = nil, editable: Bool? = true) -> [InputItem] {
         var sectionItems: [InputItem] = []
         
+        let isNoWatercraftTypeSelected =
+            object?.nonMotorized == 0 &&
+            object?.simple == 0 &&
+            object?.complex == 0 &&
+            object?.veryComplex == 0;
+        
+        let isPassportHolderNewOrLaunched = (!(object?.isPassportHolder ?? false)) ||
+        (object?.isPassportHolder ?? false && (object?.launchedOutsideBC ?? false || object?.isNewPassportIssued ?? false))
+        
         // Only allow comments once mandatory sections have been completed
-        let editable =  object?.k9InspectionInteracted ?? false &&
+        let editable =  !isNoWatercraftTypeSelected &&
+                        isPassportHolderNewOrLaunched &&
+                        object?.k9InspectionInteracted ?? false &&
                         object?.previousInspectionInteracted ?? false &&
                         object?.commerciallyHauledInteracted ?? false &&
                         object?.previousAISKnowledeInteracted ?? false &&

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -397,7 +397,7 @@ class WatercraftInspectionFormHelper {
             
             // --------- Watercraft Details Validation ---------
             if isPassportHolderNewOrLaunched &&
-                object?.numberOfPeopleInParty ?? 0 < 1 { return false }
+                object?.numberOfPeopleInParty < 1 ?? 0 { return false }
             
             if isPassportHolderNewOrLaunched &&
                 !(object?.commerciallyHauledInteracted ?? false) { return false }

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -397,6 +397,9 @@ class WatercraftInspectionFormHelper {
             
             // --------- Watercraft Details Validation ---------
             if !(object?.isPassportHolder ?? false) &&
+                object?.numberOfPeopleInParty ?? 0 < 1 { return false }
+            
+            if !(object?.isPassportHolder ?? false) &&
                 !(object?.commerciallyHauledInteracted ?? false) { return false }
                     
             if isPassportHolderNewOrLaunched &&

--- a/ipad/Models/Waterfract Inspection/WatercraftInspectionModel.swift
+++ b/ipad/Models/Waterfract Inspection/WatercraftInspectionModel.swift
@@ -587,7 +587,7 @@ class WatercraftInspectionModel: Object, BaseRealmObject {
         inputputFields[.PassportInfo] = passportFields
         inputputFields[.BasicInformation] = WatercraftInspectionFormHelper.getBasicInfoFields(for: self, editable: editable, passportField: _passportHolderField)
         inputputFields[.WatercraftDetails] = WatercraftInspectionFormHelper.getWatercraftDetailsFields(for: self, editable: editable)
-        inputputFields[.InspectionDetails] = WatercraftInspectionFormHelper.getInspectionDetailsFields(for: self, editable: editable)
+        inputputFields[.InspectionDetails] = WatercraftInspectionFormHelper.getInspectionDetailsFields(for: self, editable: editable, passportField: _passportHolderField)
         inputputFields[.GeneralComments] = WatercraftInspectionFormHelper.getGeneralCommentsFields(for: self, editable: editable)
         inputputFields[.HighRiskAssessmentFields] = WatercraftInspectionFormHelper.getHighriskAssessmentFieldsFields(for: self, editable: editable)
         inputputFields[.Divider] = []

--- a/ipad/Utilities/Theme.swift
+++ b/ipad/Utilities/Theme.swift
@@ -107,6 +107,14 @@ extension Theme {
         textField.layer.borderColor = Colors.inputBackground.cgColor
     }
     
+    public func styleFieldInputWarning(textField: UITextView) {
+        textField.textColor = Colors.warn
+        textField.backgroundColor = Colors.inputBackground
+        textField.font = getInputFieldFont()
+        textField.layer.cornerRadius = 3
+        textField.layer.borderColor = Colors.inputBackground.cgColor
+    }
+    
     // Form Section title
     public func styleSectionTitle(label: UILabel) {
         label.textColor = Colors.primary

--- a/ipad/Utilities/Theme.swift
+++ b/ipad/Utilities/Theme.swift
@@ -133,6 +133,23 @@ extension Theme {
     public func styleSectionTitle(label: UILabel) {
         label.textColor = Colors.primary
         label.font = Fonts.getPrimaryBold(size: 22)
+        
+        let attributedText = NSMutableAttributedString(string: label.text ?? "")
+
+        // Define the attributes to apply to the headings with "*" character (required)
+        let asteriskAttributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor.red,
+            .font: UIFont.boldSystemFont(ofSize: 30)
+        ]
+
+        // Loop through the label text to find any "*" characters
+        for index in 0..<(label.text?.count ?? 0) {
+            if label.text?.prefix(index + 1).hasSuffix("*") ?? false {
+                attributedText.addAttributes(asteriskAttributes, range: NSRange(location: index, length: 1))
+            }
+        }
+
+        label.attributedText = attributedText
     }
     
     // MARK: Buttons

--- a/ipad/Utilities/Theme.swift
+++ b/ipad/Utilities/Theme.swift
@@ -66,6 +66,23 @@ extension Theme {
         label.textColor = Colors.inputHeaderText
         label.font = Fonts.getPrimaryBold(size: 14)
         label.adjustsFontSizeToFitWidth = true
+
+        let attributedText = NSMutableAttributedString(string: label.text ?? "")
+
+        // Define the attributes to apply to the headings with "*" character (required)
+        let asteriskAttributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor.red,
+            .font: UIFont.boldSystemFont(ofSize: 22)
+        ]
+
+        // Loop through the label text to find any "*" characters
+        for index in 0..<(label.text?.count ?? 0) {
+            if label.text?.prefix(index + 1).hasSuffix("*") ?? false {
+                attributedText.addAttributes(asteriskAttributes, range: NSRange(location: index, length: 1))
+            }
+        }
+
+        label.attributedText = attributedText
     }
     
     // Input field content

--- a/ipad/Utilities/Theme.swift
+++ b/ipad/Utilities/Theme.swift
@@ -109,10 +109,7 @@ extension Theme {
     
     public func styleFieldInputWarning(textField: UITextView) {
         textField.textColor = Colors.warn
-        textField.backgroundColor = Colors.inputBackground
-        textField.font = getInputFieldFont()
-        textField.layer.cornerRadius = 3
-        textField.layer.borderColor = Colors.inputBackground.cgColor
+        textField.font = Fonts.getPrimaryBold(size: 14)
     }
     
     // Form Section title

--- a/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
+++ b/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
@@ -313,6 +313,12 @@ class WatercraftInspectionViewController: BaseViewController {
                     message = "\(message)\n\(counter). Please add a Previous Waterbody (Journey Details).\n"
                     counter += 1
             }
+            for prev in model.previousWaterBodies {
+                if prev.numberOfDaysOut.isEmpty {
+                    message = "\(message)\n\(counter). Please add a Number of days out of waterbody (Journey Details).\n"
+                    counter += 1
+                }
+            }
         }
         
         if isPassportHolderNewOrLaunched &&

--- a/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
+++ b/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
@@ -240,11 +240,6 @@ class WatercraftInspectionViewController: BaseViewController {
             counter += 1
         }
         
-        if !model.k9InspectionInteracted {
-            message = "\(message)\n\(counter). Please input k9 Inspection Performed field (Basic Information).\n"
-            counter += 1
-        }
-        
         // Check if any of the Watercraft types are at least greater than 0
         if isPassportHolderNewOrLaunched && isNoWatercraftTypeSelected {
           message = "\(message)\n\(counter). Please input at least one Watercraft Type (Basic Information):\n - Non-Motorized\n - Simple\n - Complex\n - Very Complex\n";
@@ -356,6 +351,11 @@ class WatercraftInspectionViewController: BaseViewController {
         if isPassportHolderNewOrLaunched &&
             !model.dreissenidMusselsFoundPreviousInteracted {
             message = "\(message)\n\(counter). Please input Dreissenid mussels found during previous inspection and FULL decontamination already completed field (Inspection Details).\n"
+            counter += 1
+        }
+        
+        if !model.k9InspectionInteracted {
+            message = "\(message)\n\(counter). Please input k9 Inspection Performed field (Inspection Details).\n"
             counter += 1
         }
         // --------- End of Inspection Details Validation ---------

--- a/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
+++ b/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
@@ -253,13 +253,13 @@ class WatercraftInspectionViewController: BaseViewController {
         // --------- End of Basic Information Validaiton ---------
         
         // --------- Watercraft Details Validation ---------
-        if !model.isPassportHolder &&
+        if isPassportHolderNewOrLaunched &&
             model.numberOfPeopleInParty < 1 {
             message = "\(message)\n\(counter). Please input the number of people in the party (Watercraft Details).\n"
             counter += 1
         }
         
-        if !model.isPassportHolder &&
+        if isPassportHolderNewOrLaunched &&
             !model.commerciallyHauledInteracted {
             message = "\(message)\n\(counter). Please input Watercraft/equipment commerically hauled field (Watercraft Details).\n"
             counter += 1

--- a/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
+++ b/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
@@ -305,7 +305,18 @@ class WatercraftInspectionViewController: BaseViewController {
         // --------- End of Watercraft Details Validaiton ---------
         
         // --------- Journey Details Validation ---------
-        if model.unknownPreviousWaterBody == true ||
+        if isPassportHolderNewOrLaunched &&
+            model.unknownPreviousWaterBody == false &&
+            model.commercialManufacturerAsPreviousWaterBody == false &&
+            model.previousDryStorage == false {
+            if model.previousWaterBodies.isEmpty {
+                    message = "\(message)\n\(counter). Please add a Previous Waterbody (Journey Details).\n"
+                    counter += 1
+            }
+        }
+        
+        if isPassportHolderNewOrLaunched &&
+            model.unknownPreviousWaterBody == true ||
             model.commercialManufacturerAsPreviousWaterBody == true ||
             model.previousDryStorage == true {
             if model.previousMajorCities.isEmpty {
@@ -313,8 +324,19 @@ class WatercraftInspectionViewController: BaseViewController {
                 counter += 1
             }
         }
+        
+        if isPassportHolderNewOrLaunched &&
+            model.unknownDestinationWaterBody == false &&
+            model.commercialManufacturerAsDestinationWaterBody == false &&
+            model.destinationDryStorage == false {
+            if model.destinationWaterBodies.isEmpty {
+                message = "\(message)\n\(counter). Please add a Destination Waterbody (Journey Details).\n"
+                counter += 1
+            }
+        }
 
-        if model.unknownDestinationWaterBody == true ||
+        if isPassportHolderNewOrLaunched &&
+            model.unknownDestinationWaterBody == true ||
             model.commercialManufacturerAsDestinationWaterBody == true ||
             model.destinationDryStorage == true {
             if model.destinationMajorCities.isEmpty {
@@ -1058,11 +1080,11 @@ extension WatercraftInspectionViewController: UICollectionViewDataSource, UIColl
             return dividerCell
         case .PreviousHeader:
             let cell = getHeaderCell(indexPath: indexPath)
-            cell.setup(with: "Previous Waterbody")
+            cell.setup(with: "Previous Waterbody *")
             return cell
         case .DestinationHeader:
             let cell = getHeaderCell(indexPath: indexPath)
-            cell.setup(with: "Destination Waterbody")
+            cell.setup(with: "Destination Waterbody *")
             return cell
         }
     }

--- a/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
+++ b/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
@@ -254,6 +254,12 @@ class WatercraftInspectionViewController: BaseViewController {
         
         // --------- Watercraft Details Validation ---------
         if !model.isPassportHolder &&
+            model.numberOfPeopleInParty < 1 {
+            message = "\(message)\n\(counter). Please input the number of people in the party (Watercraft Details).\n"
+            counter += 1
+        }
+        
+        if !model.isPassportHolder &&
             !model.commerciallyHauledInteracted {
             message = "\(message)\n\(counter). Please input Watercraft/equipment commerically hauled field (Watercraft Details).\n"
             counter += 1

--- a/ipad/Views/Form/Input Cells/TextArea Input/TextAreaInputCollectionViewCell.swift
+++ b/ipad/Views/Form/Input Cells/TextArea Input/TextAreaInputCollectionViewCell.swift
@@ -42,11 +42,18 @@ class TextAreaInputCollectionViewCell: BaseInputCell<TextAreaInput>, UITextViewD
     // MARK: Style
     override func style() {
         styleFieldInput(textField: textArea)
+        
         styleFieldHeader(label: fieldHeader)
         textArea.isScrollEnabled = true
         
         if let m = model, let value = m.value.get(type: .TextArea) as? String, value.count > charLimit {
             textArea.backgroundColor = Colors.warn.withAlphaComponent(0.3)
+        }
+        
+        // General comments is only available if all mandatory fields have been completed/interacted with
+        // The string "Complete all required fields" will appear if this is the case
+        if let m = model, m.value.get(type: m.type) as? String ?? "" == "Complete all required fields (*) to add comments." {
+            styleFieldInputWarning(textField: textArea)
         }
     }
     

--- a/ipad/Views/Form/Input Cells/TextArea Input/TextAreaInputCollectionViewCell.swift
+++ b/ipad/Views/Form/Input Cells/TextArea Input/TextAreaInputCollectionViewCell.swift
@@ -52,7 +52,7 @@ class TextAreaInputCollectionViewCell: BaseInputCell<TextAreaInput>, UITextViewD
         
         // General comments is only available if all mandatory fields have been completed/interacted with
         // The string "Complete all required fields" will appear if this is the case
-        if let m = model, m.value.get(type: m.type) as? String ?? "" == "Complete all required fields (*) to add comments." {
+        if let m = model, m.value.get(type: m.type) as? String ?? "" == "Please complete all required fields (*) before adding comments." {
             styleFieldInputWarning(textField: textArea)
         }
     }


### PR DESCRIPTION
Changelog:
- #199  
  - Moved k9 into Watercraft Inspection section, which meant that the input field for this section needed "_passportHolderField" to be passed in (as k9 inspection moves in the form if Passport is toggled "yes")
- #202 
- #206
- #207
- #215
- #217 
- #218 
  - Uses similar validation as form submission and tracks if all mandatory fields have been completed before being "editable".

- Update styling of form fields so a required field's asterisk (*) is red and prominent
- Fixed some validation logic when the Passport field is toggled as "yes"

Style changes to show required fields asterisk is more prominent:
![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-01 at 13 57 47](https://user-images.githubusercontent.com/62899351/222276325-b1371f44-da3a-4f32-b3ea-c37c469bfb2e.png)

Example of General Comments field being unavailable when a mandatory field is incomplete (Record of Decontamination number): 
![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-01 at 13 58 03](https://user-images.githubusercontent.com/62899351/222276047-c5babb73-621a-4ab6-8a0d-443223b7ca0b.png)
