### PR TITLE
[FEATURE][INSPECT-250]** Add App Store Connect certificate/provisioning to GitHub Actions (2)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,11 +17,9 @@ jobs:
       IPA_NAME: ${{ 'invasivesbc-mussels.iOS.ipa' }}
 
     steps:
-      - name: run number with offset
-        env:
-          NUM: ${{ github.run_number }}
+      - name: Increase build
         run: |
-          echo ::set-env name=GITHUB_RUN_NUMBER_WITH_OFFSET::$(($NUM+383))
+          echo "GITHUB_RUN_NUMBER_WITH_OFFSET=$(($GITHUB_RUN_NUMBER+383))" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - name: Increase build
+        env:
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           echo "GITHUB_RUN_NUMBER_WITH_OFFSET=$(($GITHUB_RUN_NUMBER+383))" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[INSPECT-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Tweak to build number increment in GitHub Actions for auto-signing and provisioning certs