### PR TITLE
[FEATURE][INSPECT-#287] - Partially Revert Journey Details Changes, Update to Validation

### DIFF
--- a/ipad.xcodeproj/project.pbxproj
+++ b/ipad.xcodeproj/project.pbxproj
@@ -214,6 +214,8 @@
 		5C82D404237B31C200B065BA /* WatercraftRiskAssessmentAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C82D403237B31C200B065BA /* WatercraftRiskAssessmentAPI.swift */; };
 		9620B078298849BF0084268C /* NullSwitchInputCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9620B076298849BF0084268C /* NullSwitchInputCollectionViewCell.swift */; };
 		9620B079298849BF0084268C /* NullSwitchInputCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9620B077298849BF0084268C /* NullSwitchInputCollectionViewCell.xib */; };
+		966B0B782B7AA1BD00B33478 /* BlankCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966B0B762B7AA1BD00B33478 /* BlankCollectionViewCell.swift */; };
+		966B0B792B7AA1BD00B33478 /* BlankCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 966B0B772B7AA1BD00B33478 /* BlankCollectionViewCell.xib */; };
 		96CDB9632B4886FF009A45C7 /* NewBlowbyModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CDB9612B4886FF009A45C7 /* NewBlowbyModal.swift */; };
 		96CDB9642B4886FF009A45C7 /* NewBlowbyModal.xib in Resources */ = {isa = PBXBuildFile; fileRef = 96CDB9622B4886FF009A45C7 /* NewBlowbyModal.xib */; };
 		A7AE5275237CC3660044DBB7 /* unapproved-cross.json in Resources */ = {isa = PBXBuildFile; fileRef = A7AE5272237CC3660044DBB7 /* unapproved-cross.json */; };
@@ -459,6 +461,8 @@
 		763C8716EF742F6764FFE7D7 /* Pods-ipad.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ipad.debug.xcconfig"; path = "Target Support Files/Pods-ipad/Pods-ipad.debug.xcconfig"; sourceTree = "<group>"; };
 		9620B076298849BF0084268C /* NullSwitchInputCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullSwitchInputCollectionViewCell.swift; sourceTree = "<group>"; };
 		9620B077298849BF0084268C /* NullSwitchInputCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NullSwitchInputCollectionViewCell.xib; sourceTree = "<group>"; };
+		966B0B762B7AA1BD00B33478 /* BlankCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlankCollectionViewCell.swift; sourceTree = "<group>"; };
+		966B0B772B7AA1BD00B33478 /* BlankCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BlankCollectionViewCell.xib; sourceTree = "<group>"; };
 		96CDB9612B4886FF009A45C7 /* NewBlowbyModal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewBlowbyModal.swift; sourceTree = "<group>"; };
 		96CDB9622B4886FF009A45C7 /* NewBlowbyModal.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NewBlowbyModal.xib; sourceTree = "<group>"; };
 		987374CFF5F2318652AA2FCC /* Pods-ipadTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ipadTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ipadTests/Pods-ipadTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1243,6 +1247,7 @@
 		29DB4E3A23870B1F00B13646 /* Shared cells */ = {
 			isa = PBXGroup;
 			children = (
+				966B0B752B7AA1A300B33478 /* Blank */,
 				29DB010B2371EE2F0046E605 /* Basic (header + Input group) */,
 				29E4BBE5237211F10079475F /* Divider */,
 				29DB0113237206B90046E605 /* Header */,
@@ -1467,6 +1472,15 @@
 			path = "Null Switch Input";
 			sourceTree = "<group>";
 		};
+		966B0B752B7AA1A300B33478 /* Blank */ = {
+			isa = PBXGroup;
+			children = (
+				966B0B762B7AA1BD00B33478 /* BlankCollectionViewCell.swift */,
+				966B0B772B7AA1BD00B33478 /* BlankCollectionViewCell.xib */,
+			);
+			path = Blank;
+			sourceTree = "<group>";
+		};
 		96CDB9602B4886FF009A45C7 /* New Blowby Modal */ = {
 			isa = PBXGroup;
 			children = (
@@ -1600,6 +1614,7 @@
 				299BF01923FC9045001732CD /* JourneyHeaderCollectionViewCell.xib in Resources */,
 				29DB4E4F2387131000B13646 /* InspectionsTableCollectionViewCell.xib in Resources */,
 				2950510A2374D764000FBD6E /* DoubleInputCollectionViewCell.xib in Resources */,
+				966B0B792B7AA1BD00B33478 /* BlankCollectionViewCell.xib in Resources */,
 				29E4BBE92372120F0079475F /* DividerCollectionViewCell.xib in Resources */,
 				296DEC21238C53930035E7FA /* NewShiftModal.xib in Resources */,
 				299BF01E23FC9D20001732CD /* PDFViewer.xib in Resources */,
@@ -1844,6 +1859,7 @@
 				5C82D3F52374D09000B065BA /* UtilityObjC.m in Sources */,
 				298BF7CC2395D45C0072AA28 /* PreviousWaterBodyModel.swift in Sources */,
 				5C82D3DE2374B9D700B065BA /* RemoteAPI.swift in Sources */,
+				966B0B782B7AA1BD00B33478 /* BlankCollectionViewCell.swift in Sources */,
 				5C82D3F92376036700B065BA /* WorkflowAPI.swift in Sources */,
 				41CAEC7D2B45C538002B2960 /* ShiftBlowbysHeaderCollectionViewCell.swift in Sources */,
 				29BAC51C2367B5B500A620F4 /* RealmRequests.swift in Sources */,

--- a/ipad/Models/Shift/ShiftModel.swift
+++ b/ipad/Models/Shift/ShiftModel.swift
@@ -43,7 +43,7 @@ class ShiftModel: Object, BaseRealmObject {
     @objc dynamic var status: String = "Draft"
     // used for query purposes (and displaying)
     // used for query purposes (and displaying)
-    @objc dynamic var formattedDate: String = ""
+    @objc dynamic var formattedDate: String = Calendar.current.startOfDay(for: Date()).stringShort()
 
     /// Takes the Date of one Date object and combines it with the Time from another date object
     /// - Parameters:

--- a/ipad/Utilities/Theme.swift
+++ b/ipad/Utilities/Theme.swift
@@ -193,4 +193,7 @@ extension Theme {
     public func styleDividerGrey(view: UIView) {
         view.backgroundColor = Colors.Status.LightGray
     }
+    public func styleTopDivider(view: UIView) {
+        view.backgroundColor = Colors.secondary
+    }
 }

--- a/ipad/ViewControllers/Shared cells/Basic (header + Input group)/BasicCollectionViewCell.swift
+++ b/ipad/ViewControllers/Shared cells/Basic (header + Input group)/BasicCollectionViewCell.swift
@@ -16,6 +16,7 @@ class BasicCollectionViewCell: UICollectionViewCell, Theme {
     @IBOutlet weak var divider: UIView!
     @IBOutlet weak var leadingMargin: NSLayoutConstraint!
     @IBOutlet weak var trailingMargin: NSLayoutConstraint!
+    @IBOutlet weak var topDivider: UIView!
     
     weak var inputGroup: UIView?
     
@@ -25,6 +26,7 @@ class BasicCollectionViewCell: UICollectionViewCell, Theme {
     
     var showBox = false
     var showDivider = true
+    var showTopDivider = false
     var extraPadding: CGFloat = 0
     var boxPadding: CGFloat = 8
     
@@ -33,12 +35,13 @@ class BasicCollectionViewCell: UICollectionViewCell, Theme {
         style()
     }
     
-    public func setup(title: String, input items: [InputItem], delegate: InputDelegate, boxed: Bool? = false, showDivider: Bool? = true, padding: CGFloat? = 0, buttonName: String? = nil, buttonIcon: String? = nil, onButtonClick: (()->Void)? = nil) {
+    public func setup(title: String, input items: [InputItem], delegate: InputDelegate, boxed: Bool? = false, showDivider: Bool? = true, showTopDivider: Bool? = false, padding: CGFloat? = 0, buttonName: String? = nil, buttonIcon: String? = nil, onButtonClick: (()->Void)? = nil) {
         self.inputGroup?.removeFromSuperview()
         
         self.extraPadding = padding ?? 0
         self.showBox = boxed ?? false
         self.showDivider = showDivider ?? true
+        self.showTopDivider = showTopDivider ?? false
         
         button.alpha = 0
         if let btnName = buttonName {
@@ -71,6 +74,7 @@ class BasicCollectionViewCell: UICollectionViewCell, Theme {
         styleSectionTitle(label: titleLabel)
         styleBox()
         styleDivider()
+        styleTopDivider()
     }
     
     private func styleBox() {
@@ -93,6 +97,15 @@ class BasicCollectionViewCell: UICollectionViewCell, Theme {
             styleDivider(view: divider)
         } else {
             divider.alpha = 0
+        }
+    }
+    
+    private func styleTopDivider() {
+        if showTopDivider {
+            topDivider.alpha = 1
+            styleTopDivider(view: topDivider)
+        } else {
+            topDivider.alpha = 0
         }
     }
     

--- a/ipad/ViewControllers/Shared cells/Basic (header + Input group)/BasicCollectionViewCell.xib
+++ b/ipad/ViewControllers/Shared cells/Basic (header + Input group)/BasicCollectionViewCell.xib
@@ -1,40 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="ipad10_9rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="BasicCollectionViewCell" customModule="InvasivesBC" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="645" height="374"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="BasicCollectionViewCell" customModule="Inspect" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="645" height="399"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="645" height="374"/>
+                <rect key="frame" x="0.0" y="0.0" width="645" height="399"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BBF-v1-4px" userLabel="TopDivider">
+                        <rect key="frame" x="0.0" y="30" width="625" height="0.0"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="2" id="k4n-s2-S1w"/>
+                        </constraints>
+                    </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bw2-kK-axj">
-                        <rect key="frame" x="0.0" y="44" width="42" height="42"/>
+                        <rect key="frame" x="0.0" y="31" width="42" height="56"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="brl-30-ocF">
-                        <rect key="frame" x="0.0" y="102" width="625" height="221"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                    </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GA1-Gd-uQy">
-                        <rect key="frame" x="0.0" y="338" width="625" height="2"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <rect key="frame" x="0.0" y="377" width="625" height="2"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="2" id="qDM-k1-ciO"/>
                         </constraints>
                     </view>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fZc-1s-7DL">
-                        <rect key="frame" x="475" y="44" width="150" height="42"/>
+                        <rect key="frame" x="475" y="38" width="150" height="42"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="42" id="dCb-bZ-KOe"/>
                             <constraint firstAttribute="width" constant="150" id="sK0-xC-IgI"/>
@@ -43,8 +48,13 @@
                             <action selector="buttonClicked:" destination="gTV-IL-0wX" eventType="touchUpInside" id="n0G-FR-ugr"/>
                         </connections>
                     </button>
+                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="brl-30-ocF">
+                        <rect key="frame" x="0.0" y="96" width="625" height="265"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
                 </subviews>
             </view>
+            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
                 <constraint firstItem="bw2-kK-axj" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="1Aa-QV-tz6"/>
                 <constraint firstAttribute="bottomMargin" secondItem="GA1-Gd-uQy" secondAttribute="bottom" id="6pz-CS-vDn"/>
@@ -52,14 +62,17 @@
                 <constraint firstItem="GA1-Gd-uQy" firstAttribute="top" secondItem="brl-30-ocF" secondAttribute="bottom" constant="15" id="8mb-MO-tKa"/>
                 <constraint firstItem="brl-30-ocF" firstAttribute="leading" secondItem="bw2-kK-axj" secondAttribute="leading" id="96F-v1-j5Z"/>
                 <constraint firstItem="GA1-Gd-uQy" firstAttribute="leading" secondItem="brl-30-ocF" secondAttribute="leading" id="9bF-Xm-lPl"/>
+                <constraint firstItem="fZc-1s-7DL" firstAttribute="trailing" secondItem="BBF-v1-4px" secondAttribute="trailing" id="C75-8y-jCf"/>
+                <constraint firstItem="BBF-v1-4px" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="30" id="HX2-cG-mAP"/>
                 <constraint firstItem="bw2-kK-axj" firstAttribute="centerY" secondItem="fZc-1s-7DL" secondAttribute="centerY" id="Ikh-db-IXG"/>
                 <constraint firstItem="fZc-1s-7DL" firstAttribute="trailing" secondItem="gTV-IL-0wX" secondAttribute="trailingMargin" id="Jyx-V8-gtb"/>
+                <constraint firstItem="bw2-kK-axj" firstAttribute="top" secondItem="BBF-v1-4px" secondAttribute="bottom" constant="1" id="ULT-0b-SA7"/>
                 <constraint firstItem="GA1-Gd-uQy" firstAttribute="trailing" secondItem="brl-30-ocF" secondAttribute="trailing" id="WoI-8J-Fgg"/>
-                <constraint firstItem="bw2-kK-axj" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="topMargin" id="v0r-iX-4cz"/>
-                <constraint firstItem="fZc-1s-7DL" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="topMargin" id="xkN-as-bTn"/>
+                <constraint firstItem="fZc-1s-7DL" firstAttribute="top" secondItem="BBF-v1-4px" secondAttribute="bottom" constant="8" symbolic="YES" id="a25-tm-dVF"/>
+                <constraint firstItem="bw2-kK-axj" firstAttribute="leading" secondItem="BBF-v1-4px" secondAttribute="leading" id="l1Z-U5-vmT"/>
+                <constraint firstItem="fZc-1s-7DL" firstAttribute="top" secondItem="BBF-v1-4px" secondAttribute="topMargin" id="xkN-as-bTn"/>
                 <constraint firstItem="brl-30-ocF" firstAttribute="top" secondItem="fZc-1s-7DL" secondAttribute="bottom" constant="16" id="yBf-zT-z0p"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <size key="customSize" width="645" height="374"/>
             <connections>
                 <outlet property="button" destination="fZc-1s-7DL" id="6i9-73-65F"/>
@@ -67,9 +80,15 @@
                 <outlet property="divider" destination="GA1-Gd-uQy" id="IHn-G1-mU4"/>
                 <outlet property="leadingMargin" destination="1Aa-QV-tz6" id="Ua1-bR-TR4"/>
                 <outlet property="titleLabel" destination="bw2-kK-axj" id="rsH-Je-rQM"/>
+                <outlet property="topDivider" destination="BBF-v1-4px" id="VGM-Sz-AAK"/>
                 <outlet property="trailingMargin" destination="8ff-Yw-O4T" id="Ktj-eR-sur"/>
             </connections>
-            <point key="canvasLocation" x="44.20289855072464" y="261.16071428571428"/>
+            <point key="canvasLocation" x="43.536585365853661" y="260.59322033898309"/>
         </collectionViewCell>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/ipad/ViewControllers/Shared cells/Blank/BlankCollectionViewCell.swift
+++ b/ipad/ViewControllers/Shared cells/Blank/BlankCollectionViewCell.swift
@@ -1,0 +1,23 @@
+//
+//  BlankCollectionViewCell.swift
+//  ipad
+//
+//  Created by Claveau, David LWRS:EX on 2024-02-12.
+//  Copyright © 2024 Amir Shayegh. All rights reserved.
+//
+
+import UIKit
+
+class BlankCollectionViewCell: UICollectionViewCell, Theme {
+
+    @IBOutlet weak var blank: UIView!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    func setup(visible: Bool) {
+        blank.alpha = visible ? 1 : 0
+    }
+
+}

--- a/ipad/ViewControllers/Shared cells/Blank/BlankCollectionViewCell.xib
+++ b/ipad/ViewControllers/Shared cells/Blank/BlankCollectionViewCell.xib
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="ipad10_9rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="BlankCollectionViewCell" customModule="Inspect" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="215" height="9"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="215" height="9"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <subviews>
+                    <view contentMode="scaleToFill" id="Z9A-p3-h1i">
+                        <rect key="frame" x="-385" y="-565" width="100" height="1"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="Kpd-Jr-o4U"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </subviews>
+            </view>
+            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
+            <size key="customSize" width="215" height="9"/>
+            <connections>
+                <outlet property="blank" destination="Z9A-p3-h1i" id="LUD-0C-nQ7"/>
+            </connections>
+            <point key="canvasLocation" x="-220" y="-2"/>
+        </collectionViewCell>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ipad/ViewControllers/Watercraft Inspections/Cells/Button/FormButtonCollectionViewCell.swift
+++ b/ipad/ViewControllers/Watercraft Inspections/Cells/Button/FormButtonCollectionViewCell.swift
@@ -29,6 +29,8 @@ class FormButtonCollectionViewCell: UICollectionViewCell, Theme {
         var isPreviousJourney: Bool = false
         var displaySwitch: Bool = false
         var displayUnknowSwitch: Bool = false
+        var otherWaterbodyPrev: Bool = false
+        var otherWaterbodyDest: Bool = false
     }
     
 
@@ -47,12 +49,38 @@ class FormButtonCollectionViewCell: UICollectionViewCell, Theme {
     @objc weak var target: NSObject?
     @objc var _selector: Selector?
     
+    var configuration = Config()
+    
     var disableButton: Bool {
-        return (dryStorageSwitch?.isOn ?? false) || (unknownWaterBodySwitch?.isOn ?? false) || (commercialManufacturerSwitch?.isOn ?? false)
+        if configuration.otherWaterbodyPrev || configuration.otherWaterbodyDest {
+            return true
+        }
+        
+        if (dryStorageSwitch?.isOn ?? false) {
+            return false
+        } else if (unknownWaterBodySwitch?.isOn ?? false) {
+            return false
+        } else if (commercialManufacturerSwitch?.isOn ?? false) {
+            return false
+        } else {
+            return true
+        }
     }
     
     var disableMajorCityButton: Bool {
-        return false
+        if configuration.otherWaterbodyPrev || configuration.otherWaterbodyDest {
+            return true
+        }
+        
+        if (dryStorageSwitch?.isOn ?? true) {
+            return false
+        } else if (unknownWaterBodySwitch?.isOn ?? true) {
+            return false
+        } else if (commercialManufacturerSwitch?.isOn ?? true) {
+            return false
+        } else {
+            return true
+        }
     }
     
     var result: Result {
@@ -64,6 +92,8 @@ class FormButtonCollectionViewCell: UICollectionViewCell, Theme {
     @IBAction func buttonAction(_ sender: UIButton) {
         // let _ = self.target?.perform(_selector, with: [:])
         guard let onClick = self.completion else {return}
+        self.set(status: disableButton)
+        self.set(status: disableMajorCityButton)
         return onClick(.add)
     }
     
@@ -111,12 +141,21 @@ class FormButtonCollectionViewCell: UICollectionViewCell, Theme {
     
     func set(status: Bool) {
         self.button?.isEnabled = !status
+        self.majorCityButton?.isEnabled = status;
         if status {
             styleDisable(button: self.button)
             styleHollowButton(button: self.majorCityButton)
         } else {
             styleHollowButton(button: button)
-            styleHollowButton(button: self.majorCityButton)
+            styleDisable(button: majorCityButton)
+        }
+        
+        // if the user has entered an otherWaterbody, we set both buttons as available
+        if configuration.otherWaterbodyPrev || configuration.otherWaterbodyDest {
+            self.button?.isEnabled = true
+            self.majorCityButton?.isEnabled = true
+            styleHollowButton(button: button)
+            styleHollowButton(button: majorCityButton)
         }
     }
     
@@ -124,6 +163,8 @@ class FormButtonCollectionViewCell: UICollectionViewCell, Theme {
         self.dryStorageSwitch?.isHidden = !config.displaySwitch
         self.switchLabel?.isHidden = !config.displaySwitch
         self.dryStorageSwitch?.isOn = config.status
+        self.configuration.otherWaterbodyPrev = config.otherWaterbodyPrev
+        self.configuration.otherWaterbodyDest = config.otherWaterbodyDest
         if config.isPreviousJourney {
             self.switchLabel?.text = "Previously Stored"
         } else {
@@ -135,7 +176,7 @@ class FormButtonCollectionViewCell: UICollectionViewCell, Theme {
         self.commercialManufacturerSwitch?.isOn = config.commercialManufacturerStatus
         
         if config.displaySwitch || config.displayUnknowSwitch {
-            set(status: (config.status || config.unknownWaterBodyStatus || config.commercialManufacturerStatus))
+            set(status: (config.status || config.unknownWaterBodyStatus || config.commercialManufacturerStatus || config.otherWaterbodyPrev || config.otherWaterbodyDest))
         } else {
             set(status: true)
         }

--- a/ipad/Views/Waterbody picker/WaterbodyPicker.xib
+++ b/ipad/Views/Waterbody picker/WaterbodyPicker.xib
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="ipad9_7" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,15 +16,15 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qen-Xp-AZo">
-                    <rect key="frame" x="0.0" y="0.0" width="1024" height="152"/>
+                    <rect key="frame" x="0.0" y="20" width="1024" height="152"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select Waterbody and Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4q1-DP-2rs">
-                            <rect key="frame" x="387.5" y="32" width="249" height="20.5"/>
+                            <rect key="frame" x="388" y="32" width="248" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iOw-hX-3E9">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iOw-hX-3E9">
                             <rect key="frame" x="16" y="32" width="40" height="33"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                             <state key="normal" title="Back"/>
@@ -38,7 +40,7 @@
                                 <string>Title</string>
                             </scopeButtonTitles>
                         </searchBar>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wKc-aW-KZS">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wKc-aW-KZS">
                             <rect key="frame" x="957" y="32" width="51" height="33"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                             <state key="normal" title="Select"/>
@@ -47,7 +49,7 @@
                             </connections>
                         </button>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstItem="cVZ-Nc-2R6" firstAttribute="leading" secondItem="Qen-Xp-AZo" secondAttribute="leading" constant="16" id="8ii-gl-TB9"/>
                         <constraint firstAttribute="trailing" secondItem="cVZ-Nc-2R6" secondAttribute="trailing" constant="16" id="Dpr-zV-qMy"/>
@@ -62,7 +64,7 @@
                     </constraints>
                 </view>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="Kn1-Cd-94q">
-                    <rect key="frame" x="8" y="160" width="1008" height="60"/>
+                    <rect key="frame" x="8" y="180" width="1008" height="60"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="60" id="cjx-4q-XHw"/>
@@ -75,11 +77,11 @@
                     </collectionViewFlowLayout>
                 </collectionView>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="2SR-r0-kTi">
-                    <rect key="frame" x="0.0" y="220" width="1024" height="548"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <rect key="frame" x="0.0" y="240" width="1024" height="528"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6g2-0s-2wB">
-                    <rect key="frame" x="64" y="216" width="896" height="254"/>
+                    <rect key="frame" x="64" y="236" width="896" height="254"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="8g6-re-zrN">
                             <rect key="frame" x="426" y="8" width="44" height="50"/>
@@ -113,7 +115,7 @@ Be sure to include the Lake Name, State/Province, Country and City.</string>
                                 <action selector="manualLocationChanged:" destination="iN0-l3-epB" eventType="editingChanged" id="Hrh-uu-nFJ"/>
                             </connections>
                         </textField>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ytn-e6-680">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ytn-e6-680">
                             <rect key="frame" x="680" y="196" width="200" height="42"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="200" id="TS0-oc-OoK"/>
@@ -131,7 +133,7 @@ Be sure to include the Lake Name, State/Province, Country and City.</string>
                             <nil key="highlightedColor"/>
                         </label>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstItem="pNE-Yy-5eH" firstAttribute="leading" secondItem="q81-if-cIf" secondAttribute="leading" id="3gj-GG-ZX1"/>
                         <constraint firstAttribute="trailing" secondItem="q81-if-cIf" secondAttribute="trailing" constant="16" id="6OS-nY-U3d"/>
@@ -153,6 +155,7 @@ Be sure to include the Lake Name, State/Province, Country and City.</string>
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Kn1-Cd-94q" secondAttribute="trailing" constant="8" id="3BG-Mh-Zxg"/>
@@ -169,7 +172,6 @@ Be sure to include the Lake Name, State/Province, Country and City.</string>
                 <constraint firstItem="Qen-Xp-AZo" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="qi0-TU-WfC"/>
                 <constraint firstItem="6g2-0s-2wB" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="64" id="xqP-DQ-wA4"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
                 <outlet property="addManuallyButton" destination="ytn-e6-680" id="GL0-49-V4x"/>
                 <outlet property="backButton" destination="iOw-hX-3E9" id="4XE-8g-Ahh"/>
@@ -186,4 +188,9 @@ Be sure to include the Lake Name, State/Province, Country and City.</string>
             <point key="canvasLocation" x="138.8671875" y="130.46875"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[INSPECT-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Partially revert the previous Journey Details changes to accommodate a new workflow. User is now only prompted to add a Closest Major City alongside a Waterbody if one of the Waterbodies added was manually entered (i.e. 'other').
- Small change to the `getJourneyDetailsCellType` function to allow this workflow, no longer provides a `.Divider` cell at the end of the call, but shows the new `.Blank` cell instead. Fixes issue where two dividers were appearing on city deletion.
- A `topDivider` is added to `BasicCollectionViewCell`, which is added to the top of **Inspection Details** to split between itself and **Journey Details**.
- Added/updated additional validation to the new workflow to allow Waterbodies without a Closest Major City, unless that Waterbody was 'other'. 