### PR TITLE
[FEATURE][INSPECT-#292] - Add a 'Add other waterbody' Button to the Waterbody Picker Table

### DIFF
--- a/ipad/Views/Waterbody picker/WaterbodyPicker.swift
+++ b/ipad/Views/Waterbody picker/WaterbodyPicker.swift
@@ -50,6 +50,8 @@ class WaterbodyPicker: UIView, Theme {
     @IBOutlet weak var addManuallyButton: UIButton!
     @IBOutlet weak var selectionsHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var manualLocationField: UITextField!
+    @IBOutlet weak var footerContainer: UIView!
+    @IBOutlet weak var otherWaterbodies: UIButton!
     
     // MARK: Constants
     private let tableCells = [
@@ -83,6 +85,10 @@ class WaterbodyPicker: UIView, Theme {
         dismissWithAnimation()
     }
     
+    @IBAction func otherWaterbodyAction(_ sender: UIButton) {
+        self.showOtherDialog()
+    }
+    
     private func dismissWithAnimation() {
         UIView.animate(withDuration: 0.3, animations: {
             self.alpha = 0
@@ -106,7 +112,7 @@ class WaterbodyPicker: UIView, Theme {
     }
     
     /**
-     Displays Wateroicker in Container and returns DropdownModel Result
+     Displays Waterpicker in Container and returns DropdownModel Result
      */
     func setup(result: @escaping([WaterBodyTableModel]) -> Void) {
         self.completion = result
@@ -220,7 +226,7 @@ class WaterbodyPicker: UIView, Theme {
         }
     }
     
-    // Filter Reaults
+    // Filter Results
     private func filter(by text: String) {
         self.otherContainer.alpha = 0
         self.filteredItems = items.filter{$0.display.lowercased().contains(text.lowercased())}.sorted(by: { (first, second) -> Bool in
@@ -290,6 +296,8 @@ class WaterbodyPicker: UIView, Theme {
         self.selectButton.setTitleColor(.white, for: .normal)
         self.searchBar.barTintColor = Colors.primary
         self.titleLabel.textColor = UIColor.white
+        self.footerContainer.backgroundColor = Colors.primary
+        self.otherWaterbodies.setTitleColor(.white, for: .normal)
         searchBar.setPlaceholderTextColorTo(color: .white)
         searchBar.setMagnifyingGlassColorTo(color: .white)
         let attributes = [

--- a/ipad/Views/Waterbody picker/WaterbodyPicker.xib
+++ b/ipad/Views/Waterbody picker/WaterbodyPicker.xib
@@ -16,16 +16,16 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qen-Xp-AZo">
-                    <rect key="frame" x="0.0" y="20" width="1024" height="152"/>
+                    <rect key="frame" x="0.0" y="0.0" width="1024" height="152"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select Waterbody and Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4q1-DP-2rs">
-                            <rect key="frame" x="388" y="32" width="248" height="20.5"/>
+                            <rect key="frame" x="388" y="47" width="248" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iOw-hX-3E9">
-                            <rect key="frame" x="16" y="32" width="40" height="33"/>
+                            <rect key="frame" x="16" y="47" width="40" height="33"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                             <state key="normal" title="Back"/>
                             <connections>
@@ -41,7 +41,7 @@
                             </scopeButtonTitles>
                         </searchBar>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wKc-aW-KZS">
-                            <rect key="frame" x="957" y="32" width="51" height="33"/>
+                            <rect key="frame" x="957" y="47" width="51" height="33"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                             <state key="normal" title="Select"/>
                             <connections>
@@ -55,16 +55,16 @@
                         <constraint firstAttribute="trailing" secondItem="cVZ-Nc-2R6" secondAttribute="trailing" constant="16" id="Dpr-zV-qMy"/>
                         <constraint firstItem="iOw-hX-3E9" firstAttribute="leading" secondItem="Qen-Xp-AZo" secondAttribute="leading" constant="16" id="Hf9-bC-IOq"/>
                         <constraint firstAttribute="bottom" secondItem="cVZ-Nc-2R6" secondAttribute="bottom" constant="16" id="L2y-7g-yP7"/>
-                        <constraint firstItem="4q1-DP-2rs" firstAttribute="top" secondItem="Qen-Xp-AZo" secondAttribute="top" constant="32" id="Nsa-55-XzG"/>
+                        <constraint firstItem="4q1-DP-2rs" firstAttribute="top" secondItem="Qen-Xp-AZo" secondAttribute="top" constant="47" id="Nsa-55-XzG"/>
                         <constraint firstAttribute="trailing" secondItem="wKc-aW-KZS" secondAttribute="trailing" constant="16" id="Sdz-ff-txo"/>
-                        <constraint firstItem="iOw-hX-3E9" firstAttribute="top" secondItem="Qen-Xp-AZo" secondAttribute="top" constant="32" id="U5N-eh-8e9"/>
+                        <constraint firstItem="iOw-hX-3E9" firstAttribute="top" secondItem="Qen-Xp-AZo" secondAttribute="top" constant="47" id="U5N-eh-8e9"/>
                         <constraint firstAttribute="height" constant="152" id="gcW-VT-1Rb"/>
                         <constraint firstItem="4q1-DP-2rs" firstAttribute="centerX" secondItem="Qen-Xp-AZo" secondAttribute="centerX" id="nLU-EX-9qj"/>
-                        <constraint firstItem="wKc-aW-KZS" firstAttribute="top" secondItem="Qen-Xp-AZo" secondAttribute="top" constant="32" id="x6z-cs-ASo"/>
+                        <constraint firstItem="wKc-aW-KZS" firstAttribute="top" secondItem="Qen-Xp-AZo" secondAttribute="top" constant="47" id="x6z-cs-ASo"/>
                     </constraints>
                 </view>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="Kn1-Cd-94q">
-                    <rect key="frame" x="8" y="180" width="1008" height="60"/>
+                    <rect key="frame" x="8" y="160" width="1008" height="60"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="60" id="cjx-4q-XHw"/>
@@ -77,11 +77,11 @@
                     </collectionViewFlowLayout>
                 </collectionView>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="2SR-r0-kTi">
-                    <rect key="frame" x="0.0" y="240" width="1024" height="528"/>
+                    <rect key="frame" x="0.0" y="220" width="1024" height="548"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6g2-0s-2wB">
-                    <rect key="frame" x="64" y="236" width="896" height="254"/>
+                    <rect key="frame" x="64" y="216" width="896" height="254"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="8g6-re-zrN">
                             <rect key="frame" x="426" y="8" width="44" height="50"/>
@@ -154,13 +154,36 @@ Be sure to include the Lake Name, State/Province, Country and City.</string>
                         <constraint firstAttribute="bottom" secondItem="pNE-Yy-5eH" secondAttribute="bottom" constant="16" id="xvw-dm-Cfb"/>
                     </constraints>
                 </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O9f-tA-CDT" userLabel="Footer">
+                    <rect key="frame" x="0.0" y="693" width="1024" height="75"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bXx-oq-iwE">
+                            <rect key="frame" x="762" y="14" width="246" height="32"/>
+                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                            <state key="normal" title="Add other waterbody not listed"/>
+                            <connections>
+                                <action selector="otherWaterbodyAction:" destination="iN0-l3-epB" eventType="touchUpInside" id="9fe-8V-tN1"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstItem="bXx-oq-iwE" firstAttribute="top" secondItem="O9f-tA-CDT" secondAttribute="top" constant="14" id="Jse-nn-wzn"/>
+                        <constraint firstAttribute="bottom" secondItem="bXx-oq-iwE" secondAttribute="bottom" constant="29" id="VYV-KP-eTu"/>
+                        <constraint firstAttribute="trailing" secondItem="bXx-oq-iwE" secondAttribute="trailing" constant="16" id="aCc-By-vdz"/>
+                        <constraint firstAttribute="height" constant="75" id="b9X-UN-Tzv"/>
+                    </constraints>
+                </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Kn1-Cd-94q" secondAttribute="trailing" constant="8" id="3BG-Mh-Zxg"/>
+                <constraint firstItem="O9f-tA-CDT" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="6hr-BW-Qu7"/>
                 <constraint firstItem="2SR-r0-kTi" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="8tI-Zq-nOY"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="2SR-r0-kTi" secondAttribute="trailing" id="92s-eU-k1Y"/>
+                <constraint firstItem="O9f-tA-CDT" firstAttribute="bottom" secondItem="iN0-l3-epB" secondAttribute="bottom" id="9LN-Yt-fM4"/>
+                <constraint firstItem="O9f-tA-CDT" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="BWG-4e-r5v"/>
                 <constraint firstItem="Qen-Xp-AZo" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="Jtn-Dc-bwi"/>
                 <constraint firstItem="Kn1-Cd-94q" firstAttribute="top" secondItem="Qen-Xp-AZo" secondAttribute="bottom" constant="8" symbolic="YES" id="WDG-Ij-e8Z"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="6g2-0s-2wB" secondAttribute="trailing" constant="64" id="WFE-Fj-3b8"/>
@@ -169,7 +192,7 @@ Be sure to include the Lake Name, State/Province, Country and City.</string>
                 <constraint firstItem="6g2-0s-2wB" firstAttribute="top" secondItem="Qen-Xp-AZo" secondAttribute="bottom" constant="64" id="flH-ph-Rcj"/>
                 <constraint firstItem="2SR-r0-kTi" firstAttribute="top" secondItem="Kn1-Cd-94q" secondAttribute="bottom" id="jGY-vY-8EF"/>
                 <constraint firstItem="Kn1-Cd-94q" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="8" id="oGa-GQ-VrU"/>
-                <constraint firstItem="Qen-Xp-AZo" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="qi0-TU-WfC"/>
+                <constraint firstItem="Qen-Xp-AZo" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="qi0-TU-WfC"/>
                 <constraint firstItem="6g2-0s-2wB" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="64" id="xqP-DQ-wA4"/>
             </constraints>
             <connections>
@@ -177,8 +200,10 @@ Be sure to include the Lake Name, State/Province, Country and City.</string>
                 <outlet property="backButton" destination="iOw-hX-3E9" id="4XE-8g-Ahh"/>
                 <outlet property="barContainer" destination="Qen-Xp-AZo" id="G3b-nT-8i8"/>
                 <outlet property="collectionView" destination="Kn1-Cd-94q" id="P76-DU-G2q"/>
+                <outlet property="footerContainer" destination="O9f-tA-CDT" id="c0y-xb-MOc"/>
                 <outlet property="manualLocationField" destination="pNE-Yy-5eH" id="G5L-pz-zTN"/>
                 <outlet property="otherContainer" destination="6g2-0s-2wB" id="A6y-VI-egE"/>
+                <outlet property="otherWaterbodies" destination="bXx-oq-iwE" id="raa-Zq-X9G"/>
                 <outlet property="searchBar" destination="cVZ-Nc-2R6" id="dn8-OD-NKg"/>
                 <outlet property="selectButton" destination="wKc-aW-KZS" id="SKE-dE-3xB"/>
                 <outlet property="selectionsHeightConstraint" destination="cjx-4q-XHw" id="RzX-Uz-fgx"/>


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[INSPECT-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Add a button to the bottom of the Waterbody picker table to allow users to more easily add an 'other' waterbody
  - When a user clicks the 'Add other waterbody not listed' button, they are immediately shown the UI to add the 'other' waterbody manually (existing functionality).
- This new button resides in a new footer container in the waterbody picker table.
- Also a small fix was made to the margins for the header in the waterbody picker table to remove whitespace; needed to move Select, Back, and Title items down slightly in the header container to accommodate margin fix.