### PR TITLE
[HOTFIX][INSPECT-#295] - Reduce padding from the Header top divider

### DIFF
--- a/ipad/ViewControllers/Shared cells/Basic (header + Input group)/BasicCollectionViewCell.xib
+++ b/ipad/ViewControllers/Shared cells/Basic (header + Input group)/BasicCollectionViewCell.xib
@@ -19,14 +19,14 @@
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BBF-v1-4px" userLabel="TopDivider">
-                        <rect key="frame" x="0.0" y="30" width="625" height="0.0"/>
+                        <rect key="frame" x="0.0" y="20" width="625" height="4"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="2" id="k4n-s2-S1w"/>
                         </constraints>
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bw2-kK-axj">
-                        <rect key="frame" x="0.0" y="31" width="42" height="56"/>
+                        <rect key="frame" x="0.0" y="25" width="42" height="56"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -39,7 +39,7 @@
                         </constraints>
                     </view>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fZc-1s-7DL">
-                        <rect key="frame" x="475" y="38" width="150" height="42"/>
+                        <rect key="frame" x="475" y="32" width="150" height="42"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="42" id="dCb-bZ-KOe"/>
                             <constraint firstAttribute="width" constant="150" id="sK0-xC-IgI"/>
@@ -63,7 +63,7 @@
                 <constraint firstItem="brl-30-ocF" firstAttribute="leading" secondItem="bw2-kK-axj" secondAttribute="leading" id="96F-v1-j5Z"/>
                 <constraint firstItem="GA1-Gd-uQy" firstAttribute="leading" secondItem="brl-30-ocF" secondAttribute="leading" id="9bF-Xm-lPl"/>
                 <constraint firstItem="fZc-1s-7DL" firstAttribute="trailing" secondItem="BBF-v1-4px" secondAttribute="trailing" id="C75-8y-jCf"/>
-                <constraint firstItem="BBF-v1-4px" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="30" id="HX2-cG-mAP"/>
+                <constraint firstItem="BBF-v1-4px" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="20" id="DJ8-tl-5RY"/>
                 <constraint firstItem="bw2-kK-axj" firstAttribute="centerY" secondItem="fZc-1s-7DL" secondAttribute="centerY" id="Ikh-db-IXG"/>
                 <constraint firstItem="fZc-1s-7DL" firstAttribute="trailing" secondItem="gTV-IL-0wX" secondAttribute="trailingMargin" id="Jyx-V8-gtb"/>
                 <constraint firstItem="bw2-kK-axj" firstAttribute="top" secondItem="BBF-v1-4px" secondAttribute="bottom" constant="1" id="ULT-0b-SA7"/>


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[INSPECT-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Reduce the padding on the Header's top divider for additional spacing from form fields; should fix any visual issues and any scrolling issues