### PR TITLE
[INSPECT-302] MAINT** Add codemagic in a venv instead of globally

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -115,6 +115,16 @@ jobs:
           retention-days: 5
 
       # https://blog.codemagic.io/app-store-connect-api-codemagic-cli-tools/
+
+      - name: Create Virtual Environment
+        if: github.ref_name == 'master'
+        run: |
+          python3 -m venv venv
+
+      - name: Activate Virtual Environment
+        if: github.ref_name == 'master'
+        run: source venv/bin/activate
+
       - name: Install Codemagic CLI Tools
         if: github.ref_name == 'master'
         run: |


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[INSPECT-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Update to Action Runner
- Install codemagic in cli since image doesn't allow global package installations