### PR TITLE
[INSPECT-301] FEATURE** Add buttons for Bilge Plugs

### DIFF
--- a/ipad.xcodeproj/project.pbxproj
+++ b/ipad.xcodeproj/project.pbxproj
@@ -2059,7 +2059,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.1;
+				MARKETING_VERSION = 2.8;
 				PRODUCT_BUNDLE_IDENTIFIER = ca.bc.gov.InvasivesBC;
 				PRODUCT_NAME = Inspect;
 				PROVISIONING_PROFILE_SPECIFIER = "InvasivesBC Muscles - 2023/24";
@@ -2089,7 +2089,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.1;
+				MARKETING_VERSION = 2.8;
 				PRODUCT_BUNDLE_IDENTIFIER = ca.bc.gov.InvasivesBC;
 				PRODUCT_NAME = Inspect;
 				PROVISIONING_PROFILE_SPECIFIER = "InvasivesBC Muscles - 2023/24";

--- a/ipad/Constants/StringConstants.swift
+++ b/ipad/Constants/StringConstants.swift
@@ -120,6 +120,8 @@ struct WatercraftFieldHeaderConstants {
         static let marineMusselsFound = "Marine mussels or barnacles found"
         static let failedToStop = "Watercraft pulled over for failing to stop at the inspection station"
         static let ticketIssued = "Violation ticket issued"
+        static let watercraftHasDrainplugs = "Does the watercraft have a drain plug located on the lower transom? *"
+        static let drainplugRemovedAtInspection = "Was the drain plug removed at the time of inspection? *"
     }
     struct HighriskAssessmentFields {
         static let highriskAIS = "The watercraft is NOT Clean, Drain, Dry after full inspection and further action must be taken AND/OR a full inspection can not be completed."

--- a/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
+++ b/ipad/Models/Waterfract Inspection/Form Fields/WatercraftInspectionFormHelper.swift
@@ -370,7 +370,30 @@ class WatercraftInspectionFormHelper {
         )
         k9InspectionResults.dependency.append(InputDependency(to: k9Inspection, equalTo: true))
         sectionItems.append(k9InspectionResults)
+          
+        let watercraftHasDrainplugs = NullSwitchInput(
+          key: "watercraftHasDrainplugs",
+          header: WatercraftFieldHeaderConstants.InspectionDetails.watercraftHasDrainplugs,
+          editable: editable ?? true,
+          value: object?.watercraftHasDrainplugs ?? nil,
+          width: .Full,
+          validationName: .watercraftHasDrainplugsInteracted,
+          interacted: object?.watercraftHasDrainplugsInteracted ?? false
+        )
+        sectionItems.append(watercraftHasDrainplugs)
         
+        let drainplugRemovedAtInspection = NullSwitchInput(
+          key: "drainplugRemovedAtInspection",
+          header: WatercraftFieldHeaderConstants.InspectionDetails.drainplugRemovedAtInspection,
+          editable: editable ?? true,
+          value: object?.drainplugRemovedAtInspection ?? nil,
+          width: .Full,
+          validationName: .drainplugRemovedAtInspectionInteracted,
+          interacted: object?.drainplugRemovedAtInspectionInteracted ?? false
+        )
+        drainplugRemovedAtInspection.dependency.append(InputDependency(to: watercraftHasDrainplugs, equalTo: true))
+        sectionItems.append(drainplugRemovedAtInspection)
+      
         return sectionItems
     }
     

--- a/ipad/Models/Waterfract Inspection/WatercraftInspectionModel.swift
+++ b/ipad/Models/Waterfract Inspection/WatercraftInspectionModel.swift
@@ -63,6 +63,8 @@ class WatercraftInspectionModel: Object, BaseRealmObject {
     @objc dynamic var marineMusselsFound: Bool = false
     @objc dynamic var cleanDrainDryAfterInspection: Bool = false
     @objc dynamic var dreissenidMusselsFoundPrevious: Bool = false
+    @objc dynamic var watercraftHasDrainplugs: Bool = false
+    @objc dynamic var drainplugRemovedAtInspection: Bool = false
     
     // Dry Storage
     @objc dynamic var previousDryStorage: Bool = false
@@ -113,17 +115,21 @@ class WatercraftInspectionModel: Object, BaseRealmObject {
                           "aquaticPlantsFound",
                           "marineMusselsFound",
                           "highRiskArea",
-                          "dreissenidMusselsFoundPrevious"]
-    @objc dynamic var highriskAISInteracted = false
-    @objc dynamic var adultDreissenidFoundInteracted = false
-    @objc dynamic var k9InspectionInteracted = false
-    @objc dynamic var previousInspectionInteracted = false
-    @objc dynamic var commerciallyHauledInteracted = false
-    @objc dynamic var previousAISKnowledeInteracted = false
-    @objc dynamic var aquaticPlantsFoundInteracted = false
-    @objc dynamic var marineMusselsFoundInteracted = false
-    @objc dynamic var highRiskAreaInteracted = false
-    @objc dynamic var dreissenidMusselsFoundPreviousInteracted = false
+                          "dreissenidMusselsFoundPrevious",
+                          "watercraftHasDrainplugs",
+                          "drainplugRemovedAtInspection"]
+    @objc dynamic var highriskAISInteracted: Bool = false
+    @objc dynamic var adultDreissenidFoundInteracted: Bool = false
+    @objc dynamic var k9InspectionInteracted: Bool = false
+    @objc dynamic var previousInspectionInteracted: Bool = false
+    @objc dynamic var commerciallyHauledInteracted: Bool = false
+    @objc dynamic var previousAISKnowledeInteracted: Bool = false
+    @objc dynamic var aquaticPlantsFoundInteracted: Bool = false
+    @objc dynamic var marineMusselsFoundInteracted: Bool = false
+    @objc dynamic var highRiskAreaInteracted: Bool = false
+    @objc dynamic var dreissenidMusselsFoundPreviousInteracted: Bool = false
+    @objc dynamic var drainplugRemovedAtInspectionInteracted: Bool = false
+    @objc dynamic var watercraftHasDrainplugsInteracted: Bool = false
     
     // MARK: Setters
     func set(value: Any, for key: String) {
@@ -304,6 +310,8 @@ class WatercraftInspectionModel: Object, BaseRealmObject {
             "inspectionTime": inspectionTime,
             "k9Inspection": k9Inspection,
             "k9InspectionResults": k9InspectionResults,
+            "watercraftHasDrainplugs": watercraftHasDrainplugs,
+            "drainplugRemovedAtInspection": drainplugRemovedAtInspection,
             "marineSpeciesFound": marineSpeciesFound,
             "aquaticPlantsFound": aquaticPlantsFound,
             "previousAISKnowledge": previousAISKnowlede,
@@ -537,7 +545,7 @@ class WatercraftInspectionModel: Object, BaseRealmObject {
                 }
             }
         } catch let error as NSError {
-            ErrorLog("** RELAM ERROR: \(error)")
+            ErrorLog("** REALM ERROR: \(error)")
         }
     }
         

--- a/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
+++ b/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
@@ -682,8 +682,7 @@ class WatercraftInspectionViewController: BaseViewController {
                 }
             }
         }
-      print(model.watercraftHasDrainplugs, model.watercraftHasDrainplugsInteracted)
-      print(model.drainplugRemovedAtInspection, model.drainplugRemovedAtInspectionInteracted)
+
         var message = ""
 
         // Build the errors into a readable format, by section

--- a/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
+++ b/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
@@ -254,6 +254,8 @@ class WatercraftInspectionViewController: BaseViewController {
         case previousInspectionInteracted               // Watercraft Details
         case dreissenidMusselsFoundPreviousInteracted   // Inspection Details
         case k9InspectionInteracted                     // Inspection Details
+        case watercraftHasDrainplugsInteracted
+        case drainplugRemovedAtInspectionInteracted
         case decontaminationPerformedInteracted         // High Risk Form
         case decontaminationOrderIssuedInteracted       // High Risk Form
         case decontaminationAppendixBInteracted         // High Risk Form
@@ -300,6 +302,8 @@ class WatercraftInspectionViewController: BaseViewController {
         case errorDecontaminationAppendixBInteracted = "Appendix B filled out field."
         case errorSealIssuedInteracted = "Seal issued or existing seal field."
         case errorQuarantinePeriodIssuedInteracted = "Quarantine period issued field."
+        case errorWatercraftHasDrainplugsInteracted = "Watercraft has Drain plugs field."
+        case errorDrainplugRemovedAtInspectionInteracted = "Drain plug removed field."
         
         // Basic
         case errorInspectionTime = "Time of Inspection."
@@ -319,7 +323,6 @@ class WatercraftInspectionViewController: BaseViewController {
         case errorDestinationMajorCities = "Closest Major City for Destination Waterbody."
         case errorPrevOtherWaterbodyNoCity = "To improve identification for the 'Other' Waterbody, add a Previous Closest Major City."
         case errorDestOtherWaterbodyNoCity = "To improve identification for the 'Other' Waterbody, add a Destination Closest Major City."
-        
         // Inspection Outcomes (High Risk form)
         case errorDecontaminationPerformed = "Record of Decontamination number."
         case errorDecontaminationOrderNumber = "Decontamination order number."
@@ -432,6 +435,18 @@ class WatercraftInspectionViewController: BaseViewController {
         /// and the corresponding errorMessage will be shown when attempting to submit
         let validationItems: [Validation] = [
             // Null Switch validation
+            Validation(
+              type: .watercraftHasDrainplugsInteracted,
+              errorMessage: .errorWatercraftHasDrainplugsInteracted,
+              condition: !model.watercraftHasDrainplugsInteracted,
+              section: .inspectionDetails
+            ),
+            Validation(
+              type: .drainplugRemovedAtInspectionInteracted,
+              errorMessage: .errorDrainplugRemovedAtInspectionInteracted,
+              condition: model.watercraftHasDrainplugs && !model.drainplugRemovedAtInspectionInteracted,
+              section: .inspectionDetails
+            ),
             Validation(
                 type: .commerciallyHauledInteracted,
                 errorMessage: .errorCommerciallyHauledInteracted,
@@ -667,7 +682,8 @@ class WatercraftInspectionViewController: BaseViewController {
                 }
             }
         }
-            
+      print(model.watercraftHasDrainplugs, model.watercraftHasDrainplugsInteracted)
+      print(model.drainplugRemovedAtInspection, model.drainplugRemovedAtInspectionInteracted)
         var message = ""
 
         // Build the errors into a readable format, by section

--- a/ipad/Views/Form/Input Cells/InputItem.swift
+++ b/ipad/Views/Form/Input Cells/InputItem.swift
@@ -52,6 +52,8 @@ enum InteractedValidationName {
     case marineMusselsFoundInteracted
     case highRiskAreaInteracted
     case dreissenidMusselsFoundPreviousInteracted
+    case watercraftHasDrainplugsInteracted
+    case drainplugRemovedAtInspectionInteracted
     // High Risk Assessment Fields
     case highriskAISInteracted
     case adultDreissenidFoundInteracted
@@ -227,6 +229,10 @@ struct InteractedWithValue {
     func get(type: InteractedValidationName) -> Bool? {
         switch type {
         // Basic Info
+        case .watercraftHasDrainplugsInteracted:
+            return self.boolean
+        case .drainplugRemovedAtInspectionInteracted:
+            return self.boolean
         case .k9InspectionInteracted:
             return self.boolean
         case .previousInspectionInteracted:
@@ -269,6 +275,10 @@ struct InteractedWithValue {
     mutating func set(value: Bool?, type: InteractedValidationName) {
         switch type {
         // Basic Info
+        case .watercraftHasDrainplugsInteracted:
+            self.boolean = value
+        case .drainplugRemovedAtInspectionInteracted:
+            self.boolean = value
         case .k9InspectionInteracted:
             self.boolean = value
         case .previousInspectionInteracted:

--- a/ipad/Views/Waterbody picker/WaterbodyPicker.xib
+++ b/ipad/Views/Waterbody picker/WaterbodyPicker.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="ipad9_7" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,8 +18,8 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qen-Xp-AZo">
                     <rect key="frame" x="0.0" y="0.0" width="1024" height="152"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select Waterbody and Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4q1-DP-2rs">
-                            <rect key="frame" x="388" y="47" width="248" height="20.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select Water body and Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4q1-DP-2rs">
+                            <rect key="frame" x="386" y="47" width="252" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -81,7 +81,7 @@
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6g2-0s-2wB">
-                    <rect key="frame" x="64" y="216" width="896" height="254"/>
+                    <rect key="frame" x="64" y="216" width="896" height="236.5"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="8g6-re-zrN">
                             <rect key="frame" x="426" y="8" width="44" height="50"/>
@@ -90,22 +90,20 @@
                                 <constraint firstAttribute="height" constant="50" id="wFC-V0-13w"/>
                             </constraints>
                         </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Toy-jT-9k1">
-                            <rect key="frame" x="16" y="110.5" width="864" height="41"/>
-                            <string key="text">Tap below to create a custom Lake and Location entry. 
-Be sure to include the Lake Name, State/Province, Country and City.</string>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Tap below to create a custom water body entry. " textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Toy-jT-9k1">
+                            <rect key="frame" x="267" y="110.5" width="365" height="21"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Waterbody and Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q81-if-cIf">
-                            <rect key="frame" x="16" y="167.5" width="864" height="20.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name of Water Body" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q81-if-cIf">
+                            <rect key="frame" x="16" y="149.5" width="864" height="21"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter Waterbody and Location" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="pNE-Yy-5eH">
-                            <rect key="frame" x="16" y="196" width="648" height="42"/>
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter Water body name" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="pNE-Yy-5eH">
+                            <rect key="frame" x="16" y="178.5" width="648" height="42"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="42" id="9lv-33-YZx"/>
                             </constraints>
@@ -116,19 +114,19 @@ Be sure to include the Lake Name, State/Province, Country and City.</string>
                             </connections>
                         </textField>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ytn-e6-680">
-                            <rect key="frame" x="680" y="196" width="200" height="42"/>
+                            <rect key="frame" x="680" y="178.5" width="200" height="42"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="200" id="TS0-oc-OoK"/>
                                 <constraint firstAttribute="height" constant="42" id="Wh2-LG-n4m"/>
                             </constraints>
-                            <state key="normal" title="Add Lake Manually"/>
+                            <state key="normal" title="Create Water Body"/>
                             <connections>
                                 <action selector="addLocationManually:" destination="iN0-l3-epB" eventType="touchUpInside" id="Jte-Qp-xWu"/>
                             </connections>
                         </button>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Is the lake you want to enter not here?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eVD-DY-WgE">
-                            <rect key="frame" x="16" y="74" width="864" height="20.5"/>
-                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Is the water body you want to enter not here?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eVD-DY-WgE">
+                            <rect key="frame" x="16" y="74" width="864" height="23"/>
+                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="19"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[INSPECT-###]`
- [x] Documentation is updated to reflect change

# Description

> Note, this PR is currently pointing at the `.dev` API and is not intended for use in production. we use Dev when letting users test the application in Testflight so not to cloud production with false data. a future PR will be made to change the target back to `.prod` once testing is approved.

This PR includes the following proposed change(s):

- Addition of two new buttons in `Watercraft Inspections` *[Figure 1.]*
    - `Does the watercraft have a drain plug located on the lower transom?` added to main form
    - `Was the drain plug removed at the time of inspection` -- Conditional question if previous button checked yes
- Buttons implemented into forms existing logic
- Simplification of existing *[Figure 2.]* `Other Waterbody` form field *[Figure 3.]*
    - Users were adding extra details here, then had to add a `Nearest Major City` from a set table causing confusion and data mismatch (We don't let them create their own Major Cities)

![image](https://github.com/bcgov/invasivesBC-mussels-iOS/assets/62873746/c16a378e-82c9-4250-9be0-292c35412559)

[Figure 1. New buttons]

<img width="535" alt="image" src="https://github.com/bcgov/invasivesBC-mussels-iOS/assets/62873746/7bbcd1cf-9f91-4af7-ac39-0cd47153ec03">

[Figure 2. Old Waterbody form field]

![image](https://github.com/bcgov/invasivesBC-mussels-iOS/assets/62873746/0a3adea2-e07a-4b0a-be5b-853fb3363919)

[Figure 3. New `Other Waterbody` form field]