### PR TITLE
[INSPECT-334][FIX]: updated timezone for shift start and ends

### DIFF
--- a/.github/workflows/pr-notification.yaml
+++ b/.github/workflows/pr-notification.yaml
@@ -2,7 +2,7 @@ name: Notify Teams on Pull Requests
 
 on:
   pull_request:
-    types: [opened, closed, reopened]
+    types: [opened, reopened]
 
 jobs:
   notify-teams:


### PR DESCRIPTION

## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[INSPECT-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- added function to account for each station timezone
- store all time values in UTC on the backend

Example of some mountain time and pacific time in the db (notice the date difference on the top 2, due to the UTC time conversion):
![Screenshot 2025-01-10 at 11 41 33 AM](https://github.com/user-attachments/assets/b8aeb3d5-924e-43af-97a2-1fd5c80c730b) 