### PR TITLE
[INSPECT-335][FEATURE] - Overnight Shift Calendar Increment

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
       ARCHIVE_NAME: ${{ 'invasivesbc-mussels.iOS.xcarchive' }}
       EXPORT_DIR: ${{ 'export' }}
       IPA_NAME: ${{ 'invasivesbc-mussels.iOS.ipa' }}
-      APP_BUILD_VERSION: "2.7.5"
+      APP_BUILD_VERSION: "2.7.6"
 
     steps:
       - uses: maxim-lobanov/setup-xcode@v1

--- a/ipad.xcodeproj/project.pbxproj
+++ b/ipad.xcodeproj/project.pbxproj
@@ -2063,7 +2063,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.8.7;
+				MARKETING_VERSION = 2.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = ca.bc.gov.InvasivesBC;
 				PRODUCT_NAME = Inspect;
 				PROVISIONING_PROFILE_SPECIFIER = "InvasivesBC Muscles - 2023/24";
@@ -2093,7 +2093,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.8.7;
+				MARKETING_VERSION = 2.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = ca.bc.gov.InvasivesBC;
 				PRODUCT_NAME = Inspect;
 				PROVISIONING_PROFILE_SPECIFIER = "InvasivesBC Muscles - 2023/24";

--- a/ipad/ViewControllers/Shift/ShiftViewController.swift
+++ b/ipad/ViewControllers/Shift/ShiftViewController.swift
@@ -198,7 +198,10 @@ class ShiftViewController: BaseViewController {
         // if can submit
         var alertMessage = "This shift and the inspections will be uploaded when possible"
         if model.shiftStartDate < Calendar.current.startOfDay(for: Date()) {
-            alertMessage += "\n\n You've entered a date that occurred before today. If this was intentional, no problem! Otherwise, please double-check the entered date: \n\(model.shiftStartDate.stringShort())"
+            alertMessage += "\n\n 🔵 You've entered a date that occurred before today. If this was intentional, no problem! Otherwise, please double-check the entered date: \n\(model.shiftStartDate.stringShort())"
+        }
+        if model.isOvernightShift() {
+            alertMessage += "\n\n 🔵 You've entered an overnight shift. This shift will carry over to the next day. If this was intentional, no problem! Otherwise, please double-check the entered shift times. \n"
         }
         if canSubmit() && model.inspections.allSatisfy({ $0.formDidValidate }) {
             Alert.show(title: "Are you sure?", message: alertMessage, yes: {[weak self] in


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[INSPECT-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Created logic to handle overnight shifts, when a shiftEnd time is before the shift start, automatically assert that the shift is overnight
- Confirmation message will pop up to allow user to confirm it is in fact an overnight shift
- If overnight, shiftEnd time will have a date of the next calendar day. 