### PR TITLE
fix[INSPECT-386]: Update SDK to 26.3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-ios:
     name: Build and sign ios
-    runs-on: macos-14
+    runs-on: macOS-26.2
 
     env:
       PROJECT: ${{ 'invasivesbc-mussels.iOS.xcworkspace' }}
@@ -15,12 +15,12 @@ jobs:
       ARCHIVE_NAME: ${{ 'invasivesbc-mussels.iOS.xcarchive' }}
       EXPORT_DIR: ${{ 'export' }}
       IPA_NAME: ${{ 'invasivesbc-mussels.iOS.ipa' }}
-      APP_BUILD_VERSION: "2.8.18"
+      APP_BUILD_VERSION: "2.8.19"
 
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.2"
+          xcode-version: "26.3"
       - name: Increase build
         env:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}

--- a/ipad.xcodeproj/project.pbxproj
+++ b/ipad.xcodeproj/project.pbxproj
@@ -2067,7 +2067,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.8.18;
+				MARKETING_VERSION = 2.8.19;
 				PRODUCT_BUNDLE_IDENTIFIER = ca.bc.gov.InvasivesBC;
 				PRODUCT_NAME = Inspect;
 				PROVISIONING_PROFILE_SPECIFIER = "InvasivesBC Muscles - 2023/24";
@@ -2097,7 +2097,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.8.18;
+				MARKETING_VERSION = 2.8.19;
 				PRODUCT_BUNDLE_IDENTIFIER = ca.bc.gov.InvasivesBC;
 				PRODUCT_NAME = Inspect;
 				PROVISIONING_PROFILE_SPECIFIER = "InvasivesBC Muscles - 2023/24";

--- a/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
+++ b/ipad/ViewControllers/Watercraft Inspections/WatercraftInspectionViewController.swift
@@ -802,7 +802,6 @@ class WatercraftInspectionViewController: BaseViewController {
                     self.showHighRiskForm(show: true)
                 }) {
                     // Cancelled
-                    // how to make this not delayed
                     model.set(value: false, for: item.key)
                     item.value.set(value: false, type: item.type)
                     NotificationCenter.default.post(name: .InputFieldShouldUpdate, object: item)


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[INSPECT-###]`
- [ ] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Update X-code SDK version to 26.3 as stated in email from app store connect
- Bumped marketing and app build versions
- Tested and app builds and runs on simulator
<img width="692" height="97" alt="Screenshot 2026-02-27 at 2 38 28 PM" src="https://github.com/user-attachments/assets/eb0af276-2994-4f5f-8728-f1f4d62fbae6" />
